### PR TITLE
Agregando validación de cliente registrado

### DIFF
--- a/src/app/modules/rentals/pages/save-reservation/save-reservation.component.ts
+++ b/src/app/modules/rentals/pages/save-reservation/save-reservation.component.ts
@@ -135,6 +135,12 @@ export class SaveReservationComponent extends BaseComponent implements OnInit
 			status: 'ACTIVE'
 		};
 
+		if (!this.reservation_info.reservation.user_id)
+		{
+			this.showError('Seleccione un cliente registrado');
+			return;
+		}
+
 		if (this.reservation_info.reservation.id == 0)
 		{
 			this.sink =this.rest_reservation_info.create(this.reservation_info)


### PR DESCRIPTION
Se agrego dentro del save-reservation.ts una validación que no permite guardarla si no existe un cliente, obligando al usuario a seleccionar uno o registrarlo.