### PR TITLE
Filtrar requisiciones por area de produccion del usuario

### DIFF
--- a/src/app/modules/shared/Empties/Storage_Type.ts
+++ b/src/app/modules/shared/Empties/Storage_Type.ts
@@ -1,0 +1,13 @@
+import { Storage_Type } from '../RestModels';
+
+export function storage_type(): Storage_Type {
+	return {
+		id: 0,
+		created_by_user_id: 0,
+		created: new Date(),
+		name: '',
+		sort_weight: 0,
+		updated_by_user_id: 0,
+		updated: new Date(),
+	};
+}

--- a/src/app/modules/shared/GetEmpty.ts
+++ b/src/app/modules/shared/GetEmpty.ts
@@ -40,6 +40,7 @@ import { transformation } from './Empties/Transformation';
 import { transformation_input } from './Empties/Transformation_Input';
 import { transformation_output } from './Empties/Transformation_Output';
 import { transformation_info } from './Empties/Transformation_Info';
+import { storage_type } from './Empties/Storage_Type';
 
 /**
  * GetEmpty class provides static methods for creating empty/default instances of models.
@@ -88,4 +89,5 @@ export class GetEmpty {
 	static transformation_input = transformation_input;
 	static transformation_output = transformation_output;
 	static transformation_info = transformation_info;
+	static storage_type = storage_type;
 }

--- a/src/app/pages/list-requisition/list-requisition.component.html
+++ b/src/app/pages/list-requisition/list-requisition.component.html
@@ -1,3 +1,4 @@
+<app-loading [is_loading]="is_loading"></app-loading>
 <div class="container-fluid">
   <div class="row my-3 align-items-center mx-0">
     <div class="col p-0">

--- a/src/app/pages/list-requisition/list-requisition.component.ts
+++ b/src/app/pages/list-requisition/list-requisition.component.ts
@@ -14,6 +14,7 @@ import { ModalComponent } from '../../components/modal/modal.component';
 import { ItemInfo, RequisitionInfo, SerialInfo, SerialItemInfo } from '../../modules/shared/Models';
 import { OrderItemsComponent } from "./order-items/order-items.component";
 import { PageStructureComponent } from '../../modules/shared/page-structure/page-structure.component';
+import { LoadingComponent } from '../../components/loading/loading.component';
 interface CRequistionItem
 {
 	item_id:number,
@@ -52,7 +53,7 @@ interface CRequisitionItem
     selector: 'app-list-requisition',
     templateUrl: './list-requisition.component.html',
     styleUrl: './list-requisition.component.css',
-    imports: [CommonModule, RouterModule, FormsModule, SearchItemsComponent, ModalComponent, OrderItemsComponent]
+    imports: [CommonModule, RouterModule, FormsModule, SearchItemsComponent, ModalComponent, OrderItemsComponent, LoadingComponent]
 })
 export class ListRequisitionComponent extends BaseComponent implements OnInit
 {
@@ -162,7 +163,7 @@ export class ListRequisitionComponent extends BaseComponent implements OnInit
 					stores: this.rest_store.search({limit:999999, eq:{status:'ACTIVE', sales_enabled: 1}}),
 					requisition: this.rest.getReport('requisitionItems', requisition_item_search),
 					production_areas: this.rest_production_area.search({eq:{store_id},limit:999999}),
-					item_production: this.getItemProductions(store_id, start_time, endtime),
+					item_production: this.getItemProductions(store_id, production_area_id, start_time, endtime),
 					users: this.rest_check_in.search({eq:{current:1},limit:999999}).pipe
 					(
 						mergeMap((response)=>
@@ -455,13 +456,18 @@ export class ListRequisitionComponent extends BaseComponent implements OnInit
 		});
 	}
 
-	getItemProductions(store_id:number, start_time: Date|null, endtime: Date|null):Observable<ItemProductions[]>
+	getItemProductions(store_id:number, production_area_id:number, start_time: Date|null, endtime: Date|null):Observable<ItemProductions[]>
 	{
 		start_time = start_time || new Date();
 
+		let eq:Record<string, any> = { store_id };
+
+		if( production_area_id )
+			eq['production_area_id'] = production_area_id;
+
 		let production_search=
 		{
-			eq:{ store_id },
+			eq,
 			lg:{ created: endtime},
 			gt:{ created: start_time},
 			limit:999999
@@ -472,6 +478,16 @@ export class ListRequisitionComponent extends BaseComponent implements OnInit
 			mergeMap((production_response)=>
 			{
 				let item_ids = production_response.data.map((pr)=>pr.item_id);
+
+				if( item_ids.length == 0 )
+				{
+					return forkJoin
+					({
+						production: of(production_response),
+						items: of({total:0, data:[]} as RestResponse<ItemInfo>)
+					});
+				}
+
 				return forkJoin
 				({
 					production: of(production_response),

--- a/src/app/pages/provider-resume/provider-resume.component.html
+++ b/src/app/pages/provider-resume/provider-resume.component.html
@@ -213,9 +213,9 @@
 											}
 										</td>
 										<td>
-											@if(purchase.shippings_info.length > 0)
+											@if(purchase.shippings.length > 0)
 											{
-												<span class="badge bg-primary">{{purchase.shippings_info.length}} envio(s)</span>
+												<span class="badge bg-primary">{{purchase.shippings.length}} envio(s)</span>
 											}
 											@else
 											{


### PR DESCRIPTION
- Pasar production_area_id a getItemProductions para filtrar la busqueda de /production por el area asignada al usuario.
- Evitar llamada a item_info cuando no hay producciones en el rango: un csv vacio era omitido por Rest y terminaba trayendo todos los items.
- Mostrar indicador de carga con <app-loading> mientras se obtienen los datos.