### PR TITLE
Agregar reporte de articulos por almacen con jerarquia

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -98,7 +98,8 @@ export const routes: Routes = [
 			{path: 'add-transformation', loadComponent: () => import('./pages/save-transformation/save-transformation.component').then(m => m.SaveTransformationComponent), canActivate: [authGuard]},
 			{path: 'edit-transformation/:id', loadComponent: () => import('./pages/save-transformation/save-transformation.component').then(m => m.SaveTransformationComponent), canActivate: [authGuard]},
 			{path: 'provider-resume', loadComponent: () => import('./pages/provider-resume/provider-resume.component').then(m => m.ProviderResumeComponent), canActivate: [authGuard]},
-			{path: 'list-batch-record', loadComponent: () => import('./pages/list-batch-record/list-batch-record.component').then(m => m.ListBatchRecordComponent), canActivate: [authGuard]}
+			{path: 'list-batch-record', loadComponent: () => import('./pages/list-batch-record/list-batch-record.component').then(m => m.ListBatchRecordComponent), canActivate: [authGuard]},
+			{path: 'list-storage-record', loadComponent: () => import('./pages/list-storage-record/list-storage-record.component').then(m => m.ListStorageRecordComponent), canActivate: [authGuard]}
 		]
 	},
 ];

--- a/src/app/modules/shared/RestModels/Storage_Item.ts
+++ b/src/app/modules/shared/RestModels/Storage_Item.ts
@@ -3,6 +3,7 @@ export interface Storage_Item {
   created_by_user_id: number;
   created: Date;
   item_id: number;
+  qty: number;
   storage_id: number;
   updated_by_user_id: number;
   updated: Date;

--- a/src/app/pages/list-storage-record/list-storage-record.component.css
+++ b/src/app/pages/list-storage-record/list-storage-record.component.css
@@ -1,0 +1,80 @@
+.pointer
+{
+	cursor: pointer;
+}
+
+.storage-group-header
+{
+	background-color: #f8f9fa;
+	user-select: none;
+}
+
+.storage-group-header:hover
+{
+	background-color: #e9ecef;
+}
+
+.storage-toggle
+{
+	display: inline-block;
+	width: 0;
+	height: 0;
+	margin-top: 0.55rem;
+	border-style: solid;
+	border-width: 6px 4px 0 4px;
+	border-color: #6c757d transparent transparent transparent;
+	transition: transform 0.15s ease;
+}
+
+.storage-toggle.collapsed
+{
+	transform: rotate(-90deg);
+}
+
+.storage-name
+{
+	font-size: 1.05rem;
+	line-height: 1.3;
+}
+
+.storage-meta
+{
+	margin-top: 0.15rem;
+	line-height: 1.3;
+}
+
+.meta-label
+{
+	font-weight: 600;
+	color: #495057;
+}
+
+.min-w-0
+{
+	min-width: 0;
+}
+
+.thead-light
+{
+	background-color: #f1f3f5;
+}
+
+@media (max-width: 575.98px)
+{
+	.storage-meta
+	{
+		display: flex;
+		flex-direction: column;
+		gap: 0.1rem;
+	}
+
+	.storage-meta .meta-sep
+	{
+		display: none;
+	}
+
+	.storage-name
+	{
+		white-space: normal;
+	}
+}

--- a/src/app/pages/list-storage-record/list-storage-record.component.html
+++ b/src/app/pages/list-storage-record/list-storage-record.component.html
@@ -1,0 +1,140 @@
+<div class="container-fluid">
+	<div class="row align-items-center mx-0">
+		<div class="col-12">
+			<h1 class="my-3">Articulos por Almacén</h1>
+		</div>
+	</div>
+
+	<div class="card py-3 p-sm-1 p-lg-3">
+		<form (submit)="performSearch(); $event.preventDefault()">
+			<div class="row mx-0">
+				<div class="col-6 col-md-3 form-group">
+					<label>Tienda</label>
+					<select name="store_id" [(ngModel)]="storage_search.eq.store_id"
+						class="form-control"
+						[disabled]="!rest.user_permission.global_add_stock">
+						<option [ngValue]="undefined">Todas</option>
+						@for (store of store_list; track store.id) {
+							<option [ngValue]="store.id">{{ store.name }}</option>
+						}
+					</select>
+				</div>
+				<div class="col-6 col-md-3 form-group">
+					<label>Tipo de almacén</label>
+					<select name="storage_type_id" [(ngModel)]="storage_search.eq.storage_type_id" class="form-control">
+						<option [ngValue]="undefined">Todos</option>
+						@for (st of storage_type_list; track st.id) {
+							<option [ngValue]="st.id">{{ st.name }}</option>
+						}
+					</select>
+				</div>
+				<div class="col-6 col-md-2 form-group">
+					<label>Almacén</label>
+					<input type="text" name="storage_name" [(ngModel)]="storage_name_filter" class="form-control" placeholder="Nombre del almacén">
+				</div>
+				<div class="col-6 col-md-2 form-group">
+					<label>Artículo</label>
+					<input type="text" name="item_name" [(ngModel)]="item_name_filter" class="form-control" placeholder="Nombre del artículo">
+				</div>
+				<div class="col-12 col-md-2 d-flex align-items-end">
+					<button type="button" class="btn btn-outline-secondary me-2 w-50" (click)="clearFilters()">Limpiar</button>
+					<button type="submit" class="btn btn-primary w-50">Buscar</button>
+				</div>
+			</div>
+		</form>
+	</div>
+
+	<app-loading [is_loading]="is_loading"></app-loading>
+
+	@if (!is_loading) {
+		@for (group of storage_groups; track group.info.storage.id) {
+			<div class="card mt-3 storage-group">
+				<div class="card-header storage-group-header pointer" (click)="toggleGroup(group)">
+					<div class="d-flex justify-content-between align-items-start gap-2">
+						<div class="d-flex align-items-start flex-grow-1 min-w-0">
+							<span class="storage-toggle me-2 flex-shrink-0"
+								[class.collapsed]="group.collapsed"></span>
+							<div class="flex-grow-1 min-w-0">
+								<div class="storage-name fw-bold text-truncate">
+									{{ group.info.storage.name || ('Almacén #' + group.info.storage.id) }}
+								</div>
+								<div class="storage-meta text-muted small">
+									<span class="meta-item">
+										<span class="meta-label">Sucursal:</span> {{ group.info.store?.name || '—' }}
+									</span>
+									<span class="meta-sep">·</span>
+									<span class="meta-item">
+										<span class="meta-label">Tipo:</span> {{ group.info.storage_type?.name || 'Sin tipo' }}
+									</span>
+								</div>
+							</div>
+						</div>
+						<span class="badge bg-primary flex-shrink-0 align-self-center">
+							{{ group.info.storage_items.length }} {{ group.info.storage_items.length === 1 ? 'artículo' : 'artículos' }}
+						</span>
+					</div>
+				</div>
+
+				@if (!group.collapsed) {
+					<div class="card-body p-0">
+						<div class="table-responsive">
+							<table class="table table-sm table-hover mb-0">
+								<thead class="thead-light">
+									<tr>
+										<th style="width: 80px">ID</th>
+										<th>Artículo</th>
+										<th style="width: 140px">Código</th>
+										<th>Ubicación</th>
+										<th class="text-end" style="width: 140px">Cantidad</th>
+									</tr>
+								</thead>
+								<tbody>
+									@for (si of group.info.storage_items; track si.storage_item.id) {
+										<tr>
+											<td>{{ si.item.id }}</td>
+											<td>
+												<strong>{{ si.item.name }}</strong>
+												@if (si.item.extra_name) {
+													<span class="text-muted ms-2">{{ si.item.extra_name }}</span>
+												}
+											</td>
+											<td>{{ si.item.code || '—' }}</td>
+											<td>
+												@if (si.leaf_storage) {
+													{{ si.leaf_storage.name || ('Almacén #' + si.leaf_storage.id) }}
+													@if (si.leaf_storages.length > 1) {
+														<span class="badge bg-secondary ms-1"
+															[title]="leafTooltip(si.leaf_storages)">
+															+{{ si.leaf_storages.length - 1 }}
+														</span>
+													}
+												} @else {
+													<span class="text-muted">—</span>
+												}
+											</td>
+											<td class="text-end">{{ si.storage_item.qty }}</td>
+										</tr>
+									} @empty {
+										<tr>
+											<td colspan="5" class="text-center text-muted py-3">
+												Este almacén no tiene artículos asignados.
+											</td>
+										</tr>
+									}
+								</tbody>
+							</table>
+						</div>
+					</div>
+				}
+			</div>
+		} @empty {
+			<div class="card mt-3">
+				<div class="card-body text-center text-muted py-4">
+					No se encontraron almacenes con los filtros aplicados.
+				</div>
+			</div>
+		}
+
+		<app-pagination [path]="path" [pages]="pages" [total_pages]="total_pages" [current_page]="current_page"></app-pagination>
+	}
+</div>

--- a/src/app/pages/list-storage-record/list-storage-record.component.ts
+++ b/src/app/pages/list-storage-record/list-storage-record.component.ts
@@ -1,0 +1,162 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ParamMap, RouterModule } from '@angular/router';
+import { forkJoin, mergeMap, of } from 'rxjs';
+
+import { BaseComponent } from '../../modules/shared/base/base.component';
+import { Rest, RestSimple, SearchObject } from '../../modules/shared/services/Rest';
+import {
+	Item,
+	Storage,
+	Storage_Item,
+	Storage_Type,
+	Store,
+} from '../../modules/shared/RestModels';
+
+import { PaginationComponent } from '../../components/pagination/pagination.component';
+import { LoadingComponent } from '../../components/loading/loading.component';
+
+interface StorageInfoItem
+{
+	storage_item: Storage_Item;
+	item: Item;
+	leaf_storage: Storage | null;
+	leaf_storages: Storage[];
+}
+
+interface StorageInfo
+{
+	storage: Storage;
+	store: Store | null;
+	storage_type: Storage_Type | null;
+	storage_items: StorageInfoItem[];
+}
+
+interface CStorageGroup
+{
+	info: StorageInfo;
+	collapsed: boolean;
+}
+
+@Component({
+	selector: 'app-list-storage-record',
+	standalone: true,
+	imports: [CommonModule, FormsModule, RouterModule, PaginationComponent, LoadingComponent],
+	templateUrl: './list-storage-record.component.html',
+	styleUrl: './list-storage-record.component.css'
+})
+export class ListStorageRecordComponent extends BaseComponent implements OnInit
+{
+	private readonly storage_search_fields = ['id', 'name', 'store_id', 'storage_type_id', 'item_name'];
+
+	rest_storage_info: Rest<Storage, StorageInfo> = this.rest.initRest<Storage, StorageInfo>('storage_info', this.storage_search_fields);
+	rest_store: RestSimple<Store> = this.rest.initRestSimple<Store>('store');
+	rest_storage_type: RestSimple<Storage_Type> = this.rest.initRestSimple<Storage_Type>('storage_type');
+
+	storage_search: SearchObject<Storage> = this.rest_storage_info.getEmptySearch();
+	storage_groups: CStorageGroup[] = [];
+
+	store_list: Store[] = [];
+	storage_type_list: Storage_Type[] = [];
+
+	item_name_filter: string = '';
+	storage_name_filter: string = '';
+
+	ngOnInit(): void
+	{
+		this.path = '/list-storage-record';
+		this.setTitle('Articulos por Almacén');
+
+		this.sink = this.route.queryParamMap.pipe
+		(
+			mergeMap((param_map: ParamMap) =>
+			{
+				this.is_loading = true;
+
+				this.storage_search = this.rest_storage_info.getSearchObject(param_map, this.storage_search_fields, []);
+				this.storage_search.limit = this.page_size;
+				this.current_page = this.storage_search.page;
+				this.item_name_filter = ((this.storage_search.lk as any).item_name as string) || '';
+				this.storage_name_filter = (this.storage_search.lk.name as string) || '';
+
+				if (!this.storage_search.eq.store_id && !this.rest.user_permission.global_add_stock)
+				{
+					this.storage_search.eq.store_id = this.rest.user?.store_id ?? undefined;
+				}
+
+				let supports_load = forkJoin
+				({
+					stores: this.store_list.length
+						? of({ data: this.store_list, total: this.store_list.length })
+						: this.rest_store.search({ limit: 999999, eq: { status: 'ACTIVE' } }),
+					storage_types: this.storage_type_list.length
+						? of({ data: this.storage_type_list, total: this.storage_type_list.length })
+						: this.rest_storage_type.search({ limit: 999999, sort_order: ['sort_weight_ASC', 'name_ASC'] })
+				});
+
+				return forkJoin
+				({
+					supports: supports_load,
+					storage_info: this.rest_storage_info.search(this.storage_search)
+				});
+			})
+		).subscribe
+		({
+			next: (response) =>
+			{
+				this.is_loading = false;
+				this.store_list = response.supports.stores.data;
+				this.storage_type_list = response.supports.storage_types.data;
+
+				this.setPages(this.current_page, response.storage_info.total);
+				this.storage_groups = response.storage_info.data.map((info) => ({
+					info,
+					collapsed: false
+				}));
+			},
+			error: (error) =>
+			{
+				this.showError(error);
+			}
+		});
+	}
+
+	performSearch(): void
+	{
+		let item_name = this.item_name_filter.trim();
+		(this.storage_search.lk as any).item_name = item_name || null;
+
+		let storage_name = this.storage_name_filter.trim();
+		this.storage_search.lk.name = storage_name || undefined;
+
+		this.search(this.storage_search);
+	}
+
+	clearFilters(): void
+	{
+		this.item_name_filter = '';
+		this.storage_name_filter = '';
+		this.storage_search = this.rest_storage_info.getEmptySearch();
+
+		if (!this.rest.user_permission.global_add_stock)
+		{
+			this.storage_search.eq.store_id = this.rest.user?.store_id ?? undefined;
+		}
+
+		this.search(this.storage_search);
+	}
+
+	toggleGroup(group: CStorageGroup): void
+	{
+		group.collapsed = !group.collapsed;
+	}
+
+	leafTooltip(leaf_storages: Storage[]): string
+	{
+		return leaf_storages
+			.slice(1)
+			.map((s) => s.name || ('Almacén #' + s.id))
+			.join(', ');
+	}
+}

--- a/src/app/pages/provider-resume/provider-resume.component.html
+++ b/src/app/pages/provider-resume/provider-resume.component.html
@@ -211,9 +211,9 @@
 											}
 										</td>
 										<td>
-											@if(purchase.shippings.length > 0)
+											@if(purchase.shippings_info.length > 0)
 											{
-												<span class="badge bg-primary">{{purchase.shippings.length}} envio(s)</span>
+												<span class="badge bg-primary">{{purchase.shippings_info.length}} envio(s)</span>
 											}
 											@else
 											{


### PR DESCRIPTION
Nuevo componente list-storage-record que agrupa por almacen raiz, agregando recursivamente los items de las hojas (qty sumada y leaf_storages). Filtros por sucursal, tipo, nombre del almacen y del articulo persistidos en query params. Header con triangulo CSS, layout responsive y badge de conteo. Tambien: campo qty en Storage_Item y fix de shippings -> shippings_info en provider-resume.