### PR TITLE
Agregando links en folio del estado de cuenta de proveedor

### DIFF
--- a/src/app/pages/reporte-estado-cuenta-proveedor/reporte-estado-cuenta-proveedor.component.html
+++ b/src/app/pages/reporte-estado-cuenta-proveedor/reporte-estado-cuenta-proveedor.component.html
@@ -115,7 +115,15 @@
 								@for (item of report_items; track item) {
 									<tr style="border: 1px solid black;">
 										<td style="border: 1px solid black; padding: 8px;">{{item.fecha | date:'dd/MM/yyyy'}}</td>
-										<td style="border: 1px solid black; padding: 8px;">{{item.folio}}</td>
+										<td style="border: 1px solid black; padding: 8px;">
+											@if (item.purchase_id) {
+												<a [attr.href]="external_base_url + '/#/purchase/edit/' + item.purchase_id">{{item.folio}}</a>
+											} @else if (item.payment_id) {
+												<a [attr.href]="external_base_url + '/#/view-payment/' + item.payment_id">{{item.folio}}</a>
+											} @else {
+												{{item.folio}}
+											}
+										</td>
 										<td style="border: 1px solid black; padding: 8px;">{{item.concepto}}</td>
 										<td style="border: 1px solid black; padding: 8px;">{{item.producto}}</td>
 										<td style="border: 1px solid black; padding: 8px; text-align: right;">{{item.cantidad}}</td>

--- a/src/app/pages/reporte-estado-cuenta-proveedor/reporte-estado-cuenta-proveedor.component.ts
+++ b/src/app/pages/reporte-estado-cuenta-proveedor/reporte-estado-cuenta-proveedor.component.ts
@@ -24,6 +24,8 @@ interface ReporteItem {
 	abono: number;
 	saldo: number;
 	dias_vencimiento: number;
+	purchase_id?: number | null;
+	payment_id?: number | null;
 }
 
 interface Balance {
@@ -51,6 +53,8 @@ export class ReporteEstadoCuentaProveedorComponent extends BaseComponent impleme
 	total_cargos: number = 0;
 	total_abonos: number = 0;
 
+	external_base_url: string = '';
+
 	report_items: ReporteItem[] = [];
 	bills_in_range: BillInfo[] = [];
 
@@ -69,6 +73,7 @@ export class ReporteEstadoCuentaProveedorComponent extends BaseComponent impleme
 
 	ngOnInit(): void {
 		this.path = '/reporte-estado-cuenta-proveedor';
+		this.external_base_url = this.rest.getExternalAppUrl();
 
 		this.sink = this.getParamsAndQueriesObservable().pipe
 		(
@@ -197,7 +202,9 @@ export class ReporteEstadoCuentaProveedorComponent extends BaseComponent impleme
 						abono: 0,
 						type: 'bill',
 						bill_id: bi.bill.id,
-						is_first_of_bill: false
+						is_first_of_bill: false,
+						purchase_id: bi.bill.purchase_id,
+						payment_id: null
 					});
 				}
 
@@ -221,7 +228,9 @@ export class ReporteEstadoCuentaProveedorComponent extends BaseComponent impleme
 					abono: 0,
 					type: 'bill',
 					bill_id: bi.bill.id,
-					is_first_of_bill: true
+					is_first_of_bill: true,
+					purchase_id: bi.bill.purchase_id,
+					payment_id: null
 				});
 			}
 		}
@@ -300,7 +309,9 @@ export class ReporteEstadoCuentaProveedorComponent extends BaseComponent impleme
 				abono: entry.amount,
 				type: 'payment',
 				bill_id: bill_ids_arr[0] || 0,
-				is_first_of_bill: false
+				is_first_of_bill: false,
+				purchase_id: null,
+				payment_id: entry.bank_movement?.payment_id ?? null
 			});
 		}
 


### PR DESCRIPTION
El folio en cada renglon ahora es link a:
- /#/purchase/edit/:id en POS cuando la fila tiene purchase_id
- /#/view-payment/:payment_id en POS cuando la fila es un pago
- Texto plano en los demas casos (factura sin orden, saldo inicial)

Sigue el patron de commission-report y el menu de Catalogos (external_base_url + ruta hash de POS).