### PR TITLE
anti doble-clic, create-primero y UI al confirmar

### DIFF
--- a/src/app/pages/validate-production/validate-production.component.html
+++ b/src/app/pages/validate-production/validate-production.component.html
@@ -49,7 +49,7 @@
           No hay producciones por validar
         </div>
       }
-      @for(pl of production_info_list;track pl.expand)
+      @for(pl of production_info_list;track pl.item_id)
         {
         <div class="row border-last border-4 align-items-center py-1">
           <div class="col-12 col-md-2 fw-bold">
@@ -90,7 +90,7 @@
                 <div class="row ">
                   <div class="col-12 mb-2 mb-lg-0 p-2 p-md-1">
                     @if (pl.production_list.length > 0) {
-                      <button type="button" class="btn btn-primary w-100" (click)="validateAll(pl)">
+                      <button type="button" class="btn btn-primary w-100" [disabled]="validating_item_ids.has(pl.item_id)" (click)="validateAll(pl)">
                         <span class="">Validar</span>
                       </button>
                     }

--- a/src/app/pages/validate-production/validate-production.component.ts
+++ b/src/app/pages/validate-production/validate-production.component.ts
@@ -56,6 +56,9 @@ export class ValidateProductionComponent extends BaseComponent
 
 	search_str:string = '';
 	search_by_code:boolean = false;
+
+	//item_ids que se estan validando en este momento (evita doble click / doble submit)
+	validating_item_ids:Set<number> = new Set<number>();
 	// show_merma_option:boolean = false;
 	// selected_merma_option:string = '';
 	// selected_production:CProduction | null = null;
@@ -193,31 +196,10 @@ export class ValidateProductionComponent extends BaseComponent
 		this.production_info_list.sort(sortFunction);
 	}
 
-	validate(pi: CProductionInfo)
-	{
-		let p = {...pi.production};
-		p.qty = pi.qty;
-		p.merma_qty = pi.merma_qty;
-
-		this.subs.sink = this.rest_production
-		.update(p)
-		.subscribe({
-			next: (response)=>
-			{
-				pi.production = response;
-				this.showSuccess('Producción validada');
-			},
-			error: (error)=>
-			{
-				this.showError( error )
-			}
-		})
-	}
-
 	validateAll(pi: CProduction)
 	{
 		//si hay mermas, se abre un modal para seleccionar la opcion de merma
-		if(pi.merma > 0 && pi.merma_reason == '')
+		if(pi.merma > 0 && (pi.merma_reason == '' || pi.merma_reason == null))
 		{
 			return this.showError('Selecciona una opción de merma');
 		}
@@ -225,67 +207,74 @@ export class ValidateProductionComponent extends BaseComponent
 		{
 			return this.showError('no puede ser null');
 		}
-		//this is not ok, should be just one call, need to find a better way to manage producion validation
+
+		//A3: evita doble click / doble submit. Cada validacion ingresa al inventario,
+		//asi que mientras una esta en proceso no se permite re-disparar la del mismo item
+		if( this.validating_item_ids.has( pi.item_id ) )
+		{
+			return;
+		}
+
 		this.subs.sink = this.confirmation.showConfirmAlert(pi,'Validar?' ,'¿Estás seguro de validar la producción?')
 		.subscribe((response)=>
 		{
-			if(response.accepted)
+			if( !response.accepted )
 			{
-				//se filtran las producciones que no han sido validadas
-				let production_info_list = pi.production_list.filter(p => !p.production.verified_by_user_id)
-
-				//ya que en el front se totaliza lo validado y la merma
-				//ahora tendremos que "repartir" entre cada una de las producciones la cantidad y merma
-				//osea, lo de los campos pl.validated y pl.merma
-
-				//se ira restando conforme a lo producido y merma de cada produccion
-				//osea que en teoria, si se reparte bien, al final todas las producciones deberian de tener la misma cantidad y merma
-				// y si hubo cambios, o salieron menos, se deberia de notificar al usuario
-
-				//por lo pronto, se hara la eliminacion de las producciones y creacion de una nueva con los datos de pl.validated y pl.merma
-				//esto poniendo el status de la produccion a DELETED
-				let production_list = production_info_list.map(p => ({...p.production, qty: p.qty, merma_qty: p.merma_qty, status: 'DELETED'}));
-				this.rest_production
-				.batchUpdate(production_list as Partial<Production>[])
-				.subscribe({
-					next: (response)=>
-					{
-						//se crea una sola nueva produccion en base a los datos de pl.validated y pl.merma
-						let newProduction:Production = GetEmpty.production();
-						newProduction.qty = pi.validated;
-						newProduction.merma_qty = pi.merma;
-						newProduction.item_id = pi.item_id;
-						newProduction.produced_by_user_id = pi.production_list[0].production.produced_by_user_id; //se toma el usuario de la primera produccion
-						newProduction.merma_reason = pi.merma_reason ? pi.merma_reason : null;
-						newProduction.qty_reported = pi.validated + pi.merma;
-						let production_area = this.production_area_list.find(pa => pa.id == this.search_production.eq.production_area_id);
-						newProduction.store_id = production_area?.store_id || pi.production_list[0].production.store_id; //se toma la tienda de la primera produccion
-						newProduction.verified_by_user_id = this.rest.user?.id as number;
-						newProduction.production_area_id = pi.production_list[0].production.production_area_id; //se toma el area de produccion de la primera produccion
-
-						//llamada de rest para crear la nueva produccion
-						this.subs.sink = this.rest_production.create(newProduction).subscribe({
-							next: (response)=>
-							{
-								this.showSuccess('Nueva produccion validada creada');
-							},
-							error: (error)=>
-							{
-								this.showError( error )
-							}
-						})
-
-						//se eliminan las producciones de la lista
-						this.production_info_list = this.production_info_list.filter(p => p.item_id != pi.item_id);
-						this.showSuccess('Producción anteriores eliminadas');
-					},
-					error: (error)=>
-					{
-						this.showError( error )
-					}
-				})
+				return;
 			}
-		})
 
+			//bloquea el boton de este item mientras se procesa
+			this.validating_item_ids.add( pi.item_id );
+
+			//producciones aun no validadas (se marcaran como DELETED al final)
+			let production_info_list = pi.production_list.filter(p => !p.production.verified_by_user_id);
+
+			//se arma la nueva produccion consolidada con lo validado y la merma
+			let newProduction:Production = GetEmpty.production();
+			newProduction.qty = pi.validated;
+			newProduction.merma_qty = pi.merma;
+			newProduction.item_id = pi.item_id;
+			newProduction.produced_by_user_id = pi.production_list[0].production.produced_by_user_id; //usuario de la primera produccion
+			newProduction.merma_reason = pi.merma_reason ? pi.merma_reason : null;
+			newProduction.qty_reported = pi.validated + pi.merma;
+			let production_area = this.production_area_list.find(pa => pa.id == this.search_production.eq.production_area_id);
+			newProduction.store_id = production_area?.store_id || pi.production_list[0].production.store_id; //tienda de la primera produccion
+			newProduction.verified_by_user_id = this.rest.user?.id as number;
+			newProduction.production_area_id = pi.production_list[0].production.production_area_id; //area de la primera produccion
+
+			//A1: primero se CREA la consolidada (que ingresa al inventario).
+			//Si esto falla, no se borro nada y se puede reintentar sin perder la produccion.
+			this.subs.sink = this.rest_production.create(newProduction)
+			.subscribe({
+				next: ()=>
+				{
+					//ya creada la consolidada, ahora si se marcan las anteriores como DELETED
+					let production_list = production_info_list.map(p => ({...p.production, qty: p.qty, merma_qty: p.merma_qty, status: 'DELETED'}));
+
+					this.rest_production.batchUpdate(production_list as Partial<Production>[])
+					.subscribe({
+						//A2: solo cuando TODO termino se limpia la vista y se notifica
+						next: ()=>
+						{
+							this.production_info_list = this.production_info_list.filter(p => p.item_id != pi.item_id);
+							this.validating_item_ids.delete( pi.item_id );
+							this.showSuccess('Producción validada');
+						},
+						error: ()=>
+						{
+							//la consolidada SI se creo, pero no se pudieron eliminar las anteriores
+							this.validating_item_ids.delete( pi.item_id );
+							this.showError('La validación se registró, pero no se pudieron eliminar las producciones anteriores. Recarga y verifica este producto antes de volver a validar.');
+						}
+					})
+				},
+				error: (error)=>
+				{
+					//no se creo nada: se libera el item para poder reintentar sin perdida
+					this.validating_item_ids.delete( pi.item_id );
+					this.showError( error );
+				}
+			})
+		})
 	}
 }


### PR DESCRIPTION

- Agrega guard validating_item_ids para evitar doble submit (doble addStock al inventario)
- Deshabilita el boton Validar mientras se procesa
- Reordena validateAll: crea la produccion consolidada antes de borrar las anteriores, para no perder produccion si falla el create
- Limpia la lista y muestra exito solo cuando create + batchUpdate confirman
- Elimina el metodo validate() sin uso
- Corrige el track de @for (pl.expand -> pl.item_id)