### PR TITLE
Reporte Recuento de Efectivo: agregar total de gastos/retiros

### DIFF
--- a/src/app/pages/report-cash-count-totals/report-cash-count-totals.component.html
+++ b/src/app/pages/report-cash-count-totals/report-cash-count-totals.component.html
@@ -84,6 +84,10 @@
 								<td colspan="2" class="text-end">Total general (MXN)</td>
 								<td class="text-end">${{grand_total_mxn | number:'1.2-2'}}</td>
 							</tr>
+							<tr class="fw-bold text-danger">
+								<td colspan="2" class="text-end">Gastos / Retiros (MXN)</td>
+								<td class="text-end">{{gastos_total_mxn ? '−' : ''}}${{gastos_total_mxn | number:'1.2-2'}}</td>
+							</tr>
 						</tfoot>
 					</table>
 				</div>

--- a/src/app/pages/report-cash-count-totals/report-cash-count-totals.component.ts
+++ b/src/app/pages/report-cash-count-totals/report-cash-count-totals.component.ts
@@ -35,6 +35,8 @@ export class ReportCashCountTotalsComponent extends BaseComponent implements OnI
 	concept_totals:{ concept:string, currency_id:string, total_amount:number }[] = [];
 	grand_total_mxn:number = 0;
 	usd_rate_used:number = 0;
+	gastos_rows:{ currency_id:string, total_gastos:number, total_movimientos:number }[] = [];
+	gastos_total_mxn:number = 0;
 
 	// Orden fijo de conceptos para el resumen tipo corte (forma de pago).
 	readonly concept_order:string[] = ['Efectivo', 'Tarjeta de crédito', 'Tarjeta de débito', 'Transferencia', 'Cheque'];
@@ -113,6 +115,7 @@ export class ReportCashCountTotalsComponent extends BaseComponent implements OnI
 				this.cash_count_list = response[2].data;
 				this.cashier_list = response[2].cashiers || [];
 				this.cashier_rows = response[2].by_cashier || [];
+				this.gastos_rows = response[2].gastos || [];
 				this.calculateTotals();
 				this.calculateCashierSummary();
 				this.is_loading = false;
@@ -210,6 +213,14 @@ export class ReportCashCountTotalsComponent extends BaseComponent implements OnI
 				this.grand_total_mxn += by_currency[currency_id] * rate;
 			}
 		}
+
+		// Total de gastos/retiros en MXN (convierte otras monedas con su tipo de cambio).
+		this.gastos_total_mxn = this.gastos_rows.reduce((acc, g) =>
+		{
+			let amount = Number(g.total_gastos) || 0;
+			let rate = g.currency_id === 'MXN' ? 1 : this.getRateForCurrency(g.currency_id);
+			return acc + amount * rate;
+		}, 0);
 	}
 
 	calculateCashierSummary()


### PR DESCRIPTION
Suma los egresos (bank_movement type != income, excluyendo tarjetas/transferencias) del periodo de cada corte y lo muestra en la card Resumen por concepto, convertido a MXN. Misma definicion que el recibo de corte del POS.