### PR TITLE
Mejoras UX en producción y envíos

### DIFF
--- a/src/app/pages/list-requisition/list-requisition.component.html
+++ b/src/app/pages/list-requisition/list-requisition.component.html
@@ -21,11 +21,11 @@
         </select>
       </div>
       <div class="col-12 col-md-3">
-        <label>Fecha Inicial</label>
+        <label>Fecha Inicial <span class="help-icon" title="Para cuándo se REQUIERE la mercancía (fecha de la requisición). No es cuándo se creó la requisición ni cuándo se produjo.">?</span></label>
         <input type="datetime-local" class="form-control" name="fecha_inicial" [(ngModel)]="fecha_inicial" (ngModelChange)="onDateChange($event,search_requisition.search_extra,'start_timestamp')">
       </div>
       <div class="col-12 col-md-3">
-        <label>Fecha Final</label>
+        <label>Fecha Final <span class="help-icon" title="Para cuándo se REQUIERE la mercancía (fecha de la requisición). No es cuándo se creó la requisición ni cuándo se produjo.">?</span></label>
         <input type="datetime-local" class="form-control" name="fecha_final" [(ngModel)]="fecha_final" (ngModelChange)="onDateChange($event,search_requisition.search_extra,'end_timestamp','',59)">
       </div>
       <div class="col-12 col-md-3">
@@ -37,7 +37,8 @@
 </div>
 <h4 class="my-3">Ordenes Especiales</h4>
 <app-order-items
-  [start_timestamp]="start_timestamp"
+  [start_timestamp]="search_requisition.search_extra['start_timestamp']"
+  [end_timestamp]="search_requisition.search_extra['end_timestamp']"
   (productionCreated)="onSpecialOrderProductionCreated($event)">
 </app-order-items>
 <h4 class="my-3">Artículos requeridos</h4>

--- a/src/app/pages/list-requisition/order-items/order-items.component.ts
+++ b/src/app/pages/list-requisition/order-items/order-items.component.ts
@@ -30,8 +30,8 @@ interface SpecialOrderItemRow
 export class OrderItemsComponent extends BaseComponent implements OnChanges
 {
 
-	@Input() start_timestamp: Date = new Date();
-	@Input() end_timestamp: Date | null = null;
+	@Input() start_timestamp: string | number | Date | null = new Date();
+	@Input() end_timestamp: string | number | Date | null = null;
 	@Output() productionCreated = new EventEmitter<{production:Production, item:Item}>();
 
 	rest_order_info:Rest<Order,OrderInfo> = this.rest.initRest('order_info');
@@ -60,18 +60,14 @@ export class OrderItemsComponent extends BaseComponent implements OnChanges
 		});
 	}
 
-	loadData(start_timestamp:Date | null = null, end_timestamp:Date | null = null): Observable<any[]>
+	loadData(start_timestamp:string | number | Date | null = null, end_timestamp:string | number | Date | null = null): Observable<any[]>
 	{
-		if( start_timestamp === null )
-			start_timestamp = new Date();
+		//coercion defensiva: los @Input pueden venir como Date o como string (del filtro de fechas del padre)
+		let start:Date = start_timestamp ? new Date(start_timestamp) : new Date();
+		//si no viene end, ventana corta de 3 dias (NO 231) para no arrastrar entregas de meses
+		let end:Date = end_timestamp ? new Date(end_timestamp) : new Date(start.getTime() + 3*24*60*60*1000);
 
-		if( end_timestamp === null )
-		{
-			end_timestamp = new Date();
-			end_timestamp.setTime( start_timestamp.getTime() + 20006400000 );
-		}
-
-		return this.rest.getReportByPath('getProductionOrderItems', { start_timestamp , end_timestamp })
+		return this.rest.getReportByPath('getProductionOrderItems', { start_timestamp: start, end_timestamp: end })
 		.pipe
 		(
 			mergeMap((response:any[]) =>

--- a/src/app/pages/list-shipping/list-shipping.component.html
+++ b/src/app/pages/list-shipping/list-shipping.component.html
@@ -4,7 +4,7 @@
       <h1 class="my-3">Envíos</h1>
     </div>
     <div class="col-12 col-md-6 text-end">
-      <a class="btn btn-secondary my-3" type="button" [routerLink]="['/add-shipping']">Envío entre sucursales</a>
+      <a class="btn btn-secondary my-3" type="button" [routerLink]="['/add-shipping']" [queryParams]="{from_store_id: selected_from_store_id}">Envío entre sucursales</a>
     </div>
   </div>
   <div class="card p-3 mb-2">
@@ -18,11 +18,11 @@
         </select>
       </div>
       <div class="col-12 col-md-3">
-        <label>Fecha y Hora Inicial</label>
+        <label>Fecha y Hora Inicial <span class="help-icon" title="Para cuándo se REQUIERE la mercancía (fecha de la requisición) y de los envíos. No es la fecha en que se produjo.">?</span></label>
         <input type="datetime-local" class="form-control" [(ngModel)]="fecha_inicial" (ngModelChange)="fechaInicialChange($event)">
       </div>
       <div class="col-12 col-md-3">
-        <label>Fecha y Hora Final</label>
+        <label>Fecha y Hora Final <span class="help-icon" title="Para cuándo se REQUIERE la mercancía (fecha de la requisición) y de los envíos. No es la fecha en que se produjo.">?</span></label>
         <input type="datetime-local" class="form-control" [(ngModel)]="fecha_final" (ngModelChange)="fechaFinalChange($event)">
       </div>
       <div class="col-12 col-md-3">
@@ -98,7 +98,7 @@
     <div class="row border-bottom align-items-center">
       <div class="col-8 col-md-3 fw-bold">{{creq.store.name}}</div>
       <div class="col-4 col-md-12 fw-bold d-lg-none order-md-3 text-end text-md">
-        <a class="btn btn-primary my-1" type="button" [routerLink]="['/add-shipping',creq.store.id, 0]">
+        <a class="btn btn-primary my-1" type="button" [routerLink]="['/add-shipping',creq.store.id, 0]" [queryParams]="{from_store_id: selected_from_store_id}">
           <svg class="d-inline d-md-none"  xmlns="http://www.w3.org/2000/svg" width="1.2em" height="1.2em" viewBox="0 0 24 24"><path fill="currentColor" d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"/></svg>
           <span class="d-none d-md-inline">Crear envío</span>
         </a>
@@ -114,7 +114,7 @@
           <div class="d-md-none col-6">Pendientes</div>
           <div class="col-6 col-md-2 col-lg-2 text-end">{{creq.pending > 0 ? creq.pending : 0}}</div>
           <div class="d-none d-lg-block col-md-4 text-end">
-            <a class="btn btn-primary my-1 text-end" type="button" [routerLink]="['/add-shipping',creq.store.id]">Crear Envio</a>
+            <a class="btn btn-primary my-1 text-end" type="button" [routerLink]="['/add-shipping',creq.store.id]" [queryParams]="{from_store_id: selected_from_store_id}">Crear Envio</a>
           </div>
         </div>
       </div>

--- a/src/app/pages/list-shipping/list-shipping.component.ts
+++ b/src/app/pages/list-shipping/list-shipping.component.ts
@@ -59,7 +59,7 @@ export class ListShippingComponent extends BaseComponent
 				}
 				else
 				{
-					this.production_search.eq.production_area_id = 1;
+					this.production_search.eq.production_area_id = this.rest.user?.production_area_id ?? 1;
 				}
 
 				if(paramMap.has('ge.created'))
@@ -125,6 +125,13 @@ export class ListShippingComponent extends BaseComponent
 				this.showError("Ocurrio un error obteniendo el reporte:" + error.message);
 			}
 		});
+	}
+
+	//tienda origen del envio = la tienda del area de produccion seleccionada en el filtro
+	get selected_from_store_id(): number | null
+	{
+		let area = this.production_area_list.find(a => a.id == this.production_search.eq.production_area_id);
+		return area?.store_id ?? null;
 	}
 
 	fechaInicialChange(fecha: string)

--- a/src/app/pages/save-shipping/save-shipping.component.html
+++ b/src/app/pages/save-shipping/save-shipping.component.html
@@ -49,7 +49,7 @@
     </div>
     <div class="my-3 row align-items-center">
       <div class="col-3 d-none d-md-inline">
-        <h4>Artículos de Requisición</h4>
+        <h4>Artículos de Requisición <span class="help-icon" title="La fecha de la derecha filtra las requisiciones por PARA CUÁNDO se requieren los artículos (fecha de la requisición).">?</span></h4>
       </div>
       <div class="col-md-3 col-6">
         <input type="date" name="requisitions_timestamp" [(ngModel)]="fecha_requisitions" class="form-control" (ngModelChange)="requisitionSearch($event, to_store_id)" required>

--- a/src/app/pages/save-shipping/save-shipping.component.ts
+++ b/src/app/pages/save-shipping/save-shipping.component.ts
@@ -101,7 +101,7 @@ export class SaveShippingComponent extends BaseComponent
 						({
 							requisitions: ids.length > 0 ? this.rest_requisition_info.search(search_requisition) : of( null ),
 							shippings: ids.length > 0 ? this.rest_shipping_info.searchAsPost({ csv:{id:ids}, eq:{from_store_id: Number(this.from_store_id), to_store_id: Number(this.to_store_id), date: this.fecha_requisitions }, limit:9999}) : of( null ),
-							production: ids.length > 0 ? this.rest_production.searchAsPost({csv:{id:ids}, limit: 999999}) : of( null ),
+							production: of( null ), //no se usa; production.php trata el POST como ALTA (no busqueda) y truena con 500
 							item_stock: ids.length > 0 ? of(itemResponse) : of( null ),
 							store: of(store!),
 						});
@@ -130,7 +130,7 @@ export class SaveShippingComponent extends BaseComponent
 
 					let shippings = response.shippings?.data;
 					let item_stock_list = response.item_stock?.data;
-					let productions_list = response.production?.data;
+					let productions_list:Production[] = [];
 
 					this.initializeCRequisitionInfo(ri, shippings, item_stock_list, productions_list, response.store);
 				}
@@ -153,7 +153,9 @@ export class SaveShippingComponent extends BaseComponent
 			{
 				this.is_loading = true;
 				this.to_store_id = parseInt(params.get('store_id') as string) || 0;
-				this.from_store_id = parseInt(this.rest.user?.store_id?.toString() || '');
+				//origen: si viene from_store_id (de list-shipping, tienda del area de produccion), usarlo; si no, la del usuario
+				let from_store_qp = this.route.snapshot.queryParamMap.get('from_store_id');
+				this.from_store_id = parseInt(from_store_qp || '') || parseInt(this.rest.user?.store_id?.toString() || '');
 				let shipping_id = params.has('id') ? parseInt(params.get('id') ?? '') : null;
 
 				let start = new Date();

--- a/src/app/pages/validate-production/validate-production.component.html
+++ b/src/app/pages/validate-production/validate-production.component.html
@@ -11,11 +11,11 @@
         </select>
       </div>
       <div class="col-12 col-md-4">
-        <label>Fecha Inicial</label>
+        <label>Fecha Inicial <span class="help-icon" title="Fecha en que se PRODUJO (se registró la producción). No es la fecha para cuándo se requiere.">?</span></label>
         <input type="datetime-local" name="search_start_date" class="form-control" [(ngModel)]="search_start_date" (ngModelChange)="onDateChange($event, search_production.ge, 'created'); search(search_production)">
       </div>
       <div class="col-12 col-md-4">
-        <label>Fecha Final</label>
+        <label>Fecha Final <span class="help-icon" title="Fecha en que se PRODUJO (se registró la producción). No es la fecha para cuándo se requiere.">?</span></label>
         <input type="datetime-local" name="search_end_date" class="form-control" [(ngModel)]="search_end_date" (ngModelChange)="onDateChange($event, search_production.le, 'created','', 59); search(search_production)">
       </div>
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,21 @@
 /* You can add global styles to this file, and also import other style files */
+
+/* Icono de ayuda "?" con tooltip (title) al pasar el mouse */
+.help-icon
+{
+	cursor: help;
+	display: inline-block;
+	width: 16px;
+	height: 16px;
+	line-height: 16px;
+	text-align: center;
+	border-radius: 50%;
+	background: #6c757d;
+	color: #fff;
+	font-size: 11px;
+	font-weight: bold;
+	margin-left: 4px;
+}
 :root
 {
   --menu-icon-color: #000000;


### PR DESCRIPTION
- Envíos: sucursal origen preseleccionada al crear envío desde list-shipping (tienda del área de producción del usuario, vía query param from_store_id). El filtro de área de producción de list-shipping arranca con la del usuario (antes fija en 1).
- Tooltips "?" en las fechas de validate-production, list-requisition, list-shipping y add-shipping, aclarando "cuándo se produjo" vs "para cuándo se requiere".
- Órdenes especiales (list-requisition) atadas al filtro de fechas de la pantalla; antes cargaban hoy + 231 días fijos. Ventana corta por defecto y tolerancia a fecha como string o Date.
- save-shipping: se elimina la consulta de producción por POST que provocaba 500 (production.php trata el POST como alta, no búsqueda).
- Nueva clase global .help-icon para el icono de ayuda.