### PR TITLE
fix(asistencia): corregir Horas en cierre de turno y registro de pago

### DIFF
--- a/src/app/pages/close-shift/close-shift.component.ts
+++ b/src/app/pages/close-shift/close-shift.component.ts
@@ -93,8 +93,19 @@ export class CloseShiftComponent extends BaseComponent implements OnInit
 				let ids = response.user.data.map((i:User)=>i.id);
 				let search_object = this.rest_check_in.getEmptySearch();
 
+				// Cargar TODOS los check-ins del día (abiertos y ya cerrados), no solo los
+				// que están en rojo (current=1). Al hacer Check OUT el backend pone current=0
+				// en todos, así que filtrar por current=1 perdía el tiempo de quien ya salió.
+				let day_start = Utils.getLocalDateFromMysqlString( this.start_date_string ) as Date;
+				let day_end = new Date( day_start );
+				day_end.setDate( day_end.getDate() + 1 );
+
 				search_object.csv['user_id'] = ids;
-				search_object.eq.current = 1;
+				// Date (no string): getString() lo convierte a UTC con toISOString(), que es como el backend
+					// compara los TIMESTAMP (conexión +00:00). Con string en hora local, los check-ins de la
+					// tarde/noche caen en el día UTC siguiente y se pierden del filtro.
+					(search_object.ge as any).start_timestamp = day_start;
+				(search_object.lt as any).start_timestamp = day_end;
 
 				return forkJoin
 				({
@@ -115,14 +126,26 @@ export class CloseShiftComponent extends BaseComponent implements OnInit
 
 				for(let user of response.users.data)
 				{
-					let work_log:Work_Log | undefined = response.work_logs.data.find((wl)=>wl.user_id == user.id );
+					let saved:Work_Log | undefined = response.work_logs.data.find((wl)=>wl.user_id == user.id );
 
 					let ws_funct = (ws:Workshift)=>ws.id == user.workshift_id;
 					let workshift:Workshift | undefined = response.workshift.data.find( ws_funct );
 					let check_ins	= response.check_ins.data.filter(checkin=>user.id == checkin.user_id );
 
-					if( !work_log )
-						work_log = this.getWorkLog( user, check_ins, workshift );
+					//Siempre recalcular desde los check-ins del día: así, al reabrir un cierre ya guardado,
+					//se reflejan las sesiones nuevas (nuevos check-in/out del mismo día).
+					let work_log = this.getWorkLog( user, check_ins, workshift );
+
+					if( saved )
+					{
+						//conservar lo capturado a mano o por otros flujos (no proviene de los check-ins)
+						work_log.id					= saved.id;
+						work_log.docking_pay		= saved.docking_pay;
+						work_log.on_time			= saved.on_time;
+						work_log.total_payment		= saved.total_payment;
+						work_log.disciplinary_actions	= saved.disciplinary_actions;
+						work_log.json_values		= saved.json_values;
+					}
 
 					result.push
 					({
@@ -151,14 +174,18 @@ export class CloseShiftComponent extends BaseComponent implements OnInit
 
 	getWorkLog(user:User,check_in_list:Check_In[], workshift:Workshift | undefined):Work_Log
 	{
-		let min_time_func = (p:number |null,check_in:Check_In) => p == null
-			? check_in.start_timestamp.getTime()
-			: Math.min(p, check_in.end_timestamp.getTime());
+		// null-safe: el intervalo abierto (aún en rojo) tiene end_timestamp = null -> se toma "ahora"
+		let min_time_func = (p:number |null,check_in:Check_In) =>
+		{
+			let start = check_in.start_timestamp ? check_in.start_timestamp.getTime() : Date.now();
+			return p == null ? start : Math.min( p, start );
+		};
 
 		let max_time_func = (p:number |null,check_in:Check_In) =>
-			p == null || check_in.end_timestamp== null
-			? p
-			: Math.max( p, check_in.end_timestamp.getTime() );
+		{
+			let end = check_in.end_timestamp ? check_in.end_timestamp.getTime() : Date.now();
+			return p == null ? end : Math.max( p, end );
+		};
 
 
 		let min_time	= check_in_list.reduce( min_time_func, null);

--- a/src/app/pages/list-user-attendance/list-user-attendance.component.ts
+++ b/src/app/pages/list-user-attendance/list-user-attendance.component.ts
@@ -167,8 +167,9 @@ export class ListUserAttendanceComponent extends BaseComponent
 					({
 						user,
 						work_log: work_logs,
-						total_hours,
-						extra_hours,
+						//redondeo a 2 decimales: evita ruido de punto flotante al sumar (0.02+0.05+0.02 = 0.09000000000000001)
+						total_hours: Math.round( total_hours * 100 ) / 100,
+						extra_hours: Math.round( extra_hours * 100 ) / 100,
 						late_arrives
 					});
 					//current_check_in: response.check_ins.data.find(checkin=>i.id == checkin.user_id ) || null

--- a/src/app/pages/save-production-payment/save-production-payment.component.ts
+++ b/src/app/pages/save-production-payment/save-production-payment.component.ts
@@ -195,17 +195,15 @@ export class SaveProductionPaymentComponent extends BaseComponent implements OnI
 			{
 				total_hours += work_log.hours;
 				total_extra_hours += work_log.extra_hours;
-				if (work_log.total_payment)
-				{
-					total_payment += work_log.total_payment;
-				}
 			});
 
 			//gettin the productions of this user
-			let user_productions = productions.filter((production) => production.produced_by_user_id == user.id);
+			//Si produced_by_user_id viene NULL, se atribuye a created_by_user_id (mismo fallback que el backend: production.php:124)
+			let user_productions = productions.filter((production) => (production.produced_by_user_id ?? production.created_by_user_id) == user.id);
 
 			let cost = 0;
 			let production_qty = 0;
+			let merma_qty = 0;
 			user_productions.forEach((production)=>
 			{
 				let item = items.find((ii)=>ii.item.id == production.item_id);
@@ -214,6 +212,7 @@ export class SaveProductionPaymentComponent extends BaseComponent implements OnI
 					cost += production.qty * item.item.reference_price;
 				}
 				production_qty += production.qty;
+				merma_qty += production.merma_qty;
 			});
 
 			let rules = this.json_rules_list.filter((rule)=>rule.store_id == user.store_id);
@@ -233,8 +232,10 @@ export class SaveProductionPaymentComponent extends BaseComponent implements OnI
 				total_extra_hours,
 				total_users,
 				total_prod: payment_total,
+				total_merma: this.merma_total,
 				individual_prod: production_qty,
-				individual_cost: cost
+				individual_cost: cost,
+				individual_merma: merma_qty
 			};
 
 			let json_values: Record<string, any> = {};
@@ -252,13 +253,12 @@ export class SaveProductionPaymentComponent extends BaseComponent implements OnI
 				}
 			});
 
-			//console.log('json_values', json_values);
-			if (total_payment == 0)
+			//Recalcular SIEMPRE el pago desde las reglas (automático): no quedarse pegado en lo ya guardado,
+			//así al reabrir el Registro de Pago refleja la producción actual del día.
+			total_payment = 0;
+			for (let key in json_values)
 			{
-				for (let key in json_values)
-				{
-					total_payment += json_values[key];
-				}
+				total_payment += json_values[key];
 			}
 
 			this.Cuser_production_report_list.push({ user, total_hours, total_extra_hours, production_qty, cost, json_values, total_payment });


### PR DESCRIPTION
- close-shift: cargar todos los check-ins del dia (no solo current=1), recalcular siempre desde los check-ins, y fix de zona horaria en el filtro (pasar Date en vez de string local; el backend compara TIMESTAMP en UTC y perdia los check-ins de la tarde/noche).
- save-production-payment: atribuir produccion con fallback a created_by_user_id cuando produced_by_user_id es NULL; exponer merma (individual_merma/total_merma) como variable de las reglas de pago; recalcular el pago siempre.
- list-user-attendance: redondear total de horas/extras a 2 decimales (ruido de punto flotante).