### PR TITLE
feat(pago-produccion): reglas de pago por area en vez de por sucursal

### DIFF
--- a/src/app/modules/shared/Empties/Work_Log_Rules.ts
+++ b/src/app/modules/shared/Empties/Work_Log_Rules.ts
@@ -4,6 +4,7 @@ export function work_log_rules(): Work_Log_Rules {
 	return {
 		id: 0,
 		store_id: 0,
+		production_area_id: null,
 		json_rules: {}
 	};
 }

--- a/src/app/modules/shared/RestModels/Work_Log_Rules.ts
+++ b/src/app/modules/shared/RestModels/Work_Log_Rules.ts
@@ -1,6 +1,7 @@
 export interface Work_Log_Rules {
   id: number;
   json_rules: any | null;
+  production_area_id: number | null;
   store_id: number;
 }
 

--- a/src/app/pages/save-production-payment/save-production-payment.component.ts
+++ b/src/app/pages/save-production-payment/save-production-payment.component.ts
@@ -261,7 +261,18 @@ export class SaveProductionPaymentComponent extends BaseComponent implements OnI
 				merma_qty += production.merma_qty;
 			});
 
-			let rules = this.json_rules_list.filter((rule)=>rule.store_id == user.store_id);
+			//Las reglas se resuelven por AREA de produccion, que es la dimension con la que trabaja
+			//toda esta pantalla (la produccion, los usuarios listados y total_users salen del area).
+			let area_rules = this.json_rules_list
+				.filter((rule)=> rule.production_area_id != null && rule.production_area_id == this.production_area_id);
+
+			//Solo si el area no tiene regla propia se cae al esquema viejo por tienda, para no dejar
+			//sin pago a nadie durante la migracion. Es excluyente a proposito: si se acumularan, un
+			//usuario con regla de area Y regla de su tienda cobraria las dos. Cuando todas las reglas
+			//tengan area, esta segunda rama se puede borrar.
+			let rules = area_rules.length
+				? area_rules
+				: this.json_rules_list.filter((rule)=> rule.production_area_id == null && rule.store_id == user.store_id);
 
 			//tmp obj with all the rules to be evaluated
 			let props = {};
@@ -299,13 +310,18 @@ export class SaveProductionPaymentComponent extends BaseComponent implements OnI
 				}
 			});
 
-			//Recalcular SIEMPRE el pago desde las reglas (automático): no quedarse pegado en lo ya guardado,
-			//así al reabrir el Registro de Pago refleja la producción actual del día.
-			total_payment = 0;
+			//Lo que dictan las reglas hoy, que es lo que se muestra en las columnas de json_values
+			let calculated_payment = 0;
 			for (let key in json_values)
 			{
-				total_payment += json_values[key];
+				calculated_payment += json_values[key];
 			}
+
+			//El input arranca con lo YA GUARDADO si existe: antes se sobreescribia siempre con el
+			//calculo, asi que cualquier ajuste manual se perdia al recargar (y si ese dia no habia
+			//produccion validada, el monto capturado se veia como 0 aunque estuviera en la base).
+			let saved_payment = user_work_logs.reduce((total, work_log) => total + (work_log.total_payment || 0), 0);
+			total_payment = saved_payment > 0 ? saved_payment : calculated_payment;
 
 			this.Cuser_production_report_list.push({ user, total_hours, total_extra_hours, production_qty, cost, json_values, total_payment });
 		});

--- a/src/app/pages/save-worklog-rules/save-worklog-rules.component.html
+++ b/src/app/pages/save-worklog-rules/save-worklog-rules.component.html
@@ -4,14 +4,32 @@
       <h1>Variables de pago</h1>
     </div>
     <div class="col-4 text-end">
-      <button class="btn btn-primary" (click)="addRule()">
+      <button class="btn btn-primary" (click)="addRule()" [disabled]="!production_area_id">
         <svg xmlns="http://www.w3.org/2000/svg" width="1.6em" height="1.6em" viewBox="0 0 24 24"><path fill="currentColor" d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6z"/></svg>
         Agregar
       </button>
     </div>
   </div>
 
-  <div class="card p-3">
+  <div class="card p-3 mb-3">
+    <div class="row">
+      <div class="col-12 col-md-6">
+        <label for="production_area_id" class="fw-bold">Área de Producción</label>
+        <select class="form-control" id="production_area_id" [(ngModel)]="production_area_id" (ngModelChange)="onAreaChange()">
+          <option [ngValue]="null">Selecciona un área</option>
+          @for (pa of production_area_list; track pa.id) {
+            <option [ngValue]="pa.id">{{pa.name}}</option>
+          }
+        </select>
+      </div>
+    </div>
+  </div>
+
+  @if (!production_area_id) {
+    <div class="alert alert-info">Selecciona un área de producción para ver o capturar sus variables de pago.</div>
+  }
+
+  <div class="card p-3" [class.d-none]="!production_area_id">
     <div class="row">
       <div class="d-none d-sm-block col-4 fw-bold">
         Clave

--- a/src/app/pages/save-worklog-rules/save-worklog-rules.component.ts
+++ b/src/app/pages/save-worklog-rules/save-worklog-rules.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { BaseComponent } from '../../modules/shared/base/base.component';
-import { Work_Log_Rules } from '../../modules/shared/RestModels';
+import { Production_Area, Work_Log_Rules } from '../../modules/shared/RestModels';
 import { RestSimple } from '../../modules/shared/services/Rest';
-import { mergeMap } from 'rxjs';
+import { forkJoin, mergeMap, of } from 'rxjs';
 import { FormsModule } from '@angular/forms';
 import { GetEmpty } from '../../modules/shared/GetEmpty';
 
@@ -21,31 +21,62 @@ interface Rule {
 export class SaveWorklogRulesComponent extends BaseComponent implements OnInit {
 
 	rest_work_log_rules:RestSimple<Work_Log_Rules> = this.rest.initRestSimple('work_log_rules');
+	rest_production_area:RestSimple<Production_Area> = this.rest.initRestSimple('production_area');
 
 	work_log_rules:Work_Log_Rules = GetEmpty.work_log_rules();
 	array_rules:Rule[] = [];
 
+	production_area_list:Production_Area[] = [];
+	production_area_id:number | null = null;
+
 	ngOnInit(): void {
+
+		this.path = 'save-worklog-rules';
+
 		this.subs.sink = this.route.queryParamMap
 		.pipe
 		(
 			mergeMap(params => {
-				let store_id = this.rest.user?.store_id as number;
 				this.is_loading = true;
-				return this.rest_work_log_rules.search({ eq:{store_id: store_id} ,limit: 1 });
+
+				let param_area = params.get('eq.production_area_id');
+				this.production_area_id = param_area && param_area !== 'null' ? parseInt( param_area ) : null;
+
+				return forkJoin
+				({
+					production_area: this.rest_production_area.search({ eq:{ status:'ACTIVE' }, limit: 9999, sort_order:['name_ASC'] }),
+					//Las reglas viven por area; mientras no se elija una no hay nada que cargar
+					rules: this.production_area_id
+						? this.rest_work_log_rules.search({ eq:{ production_area_id: this.production_area_id }, limit: 1 })
+						: of(null)
+				});
 			})
 		)
 		.subscribe({
 			next: (result) => {
 				this.is_loading = false;
-				this.work_log_rules = result.data[0];
-				if( this.work_log_rules )
+
+				this.production_area_list = result.production_area.data;
+
+				//Reiniciar siempre: buildRules solo agrega, y al cambiar de area se duplicarian los renglones
+				this.array_rules = [];
+				this.work_log_rules = result.rules?.data[0] ?? GetEmpty.work_log_rules();
+
+				if( this.work_log_rules.id )
+				{
 					this.buildRules();
+				}
 			},
 			error: (error) => {
+				this.is_loading = false;
 				this.showError(error);
 			}
 		});
+	}
+
+	onAreaChange()
+	{
+		this.router.navigate([this.path], { queryParams: { 'eq.production_area_id': this.production_area_id } });
 	}
 
 	buildRules()
@@ -75,7 +106,12 @@ export class SaveWorklogRulesComponent extends BaseComponent implements OnInit {
 	save(evt: Event)
 	{
 		evt.preventDefault();
-		this.is_loading = true;
+
+		if( !this.production_area_id )
+		{
+			this.showWarning('Selecciona un área de producción');
+			return;
+		}
 
 		//convert array to object
 		let rules:Record<string, string> = {};
@@ -84,24 +120,30 @@ export class SaveWorklogRulesComponent extends BaseComponent implements OnInit {
 			rules[key] = rule.value;
 		});
 
-		console.log(rules);
-		console.log(this.work_log_rules);
-		if(!this.work_log_rules)
-		{
-			this.work_log_rules = GetEmpty.work_log_rules();
-			this.work_log_rules.store_id = this.rest.user?.store_id as number;
-		}
 		this.work_log_rules.json_rules = rules;
+		this.work_log_rules.production_area_id = this.production_area_id;
 
-		//RULE PARA TECATE
-		// user.master ? production.total_prod * 0.2 : (production.total_prod * 0.1) / production.total_users
+		//store_id ya no decide a quien se le aplica la regla, pero la columna sigue siendo NOT NULL:
+		//se llena con la tienda del area para que el registro quede coherente.
+		let area = this.production_area_list.find((pa) => pa.id == this.production_area_id);
 
+		if( area )
+		{
+			this.work_log_rules.store_id = area.store_id;
+		}
+
+		this.is_loading = true;
+
+		//El backend hace upsert: sin id inserta, con id actualiza
 		this.subs.sink = this.rest_work_log_rules.update(this.work_log_rules)
 		.subscribe({
 			next: (result) => {
+				this.is_loading = false;
+				this.work_log_rules = result;
 				this.showSuccess('Reglas guardadas');
 			},
 			error: (error) => {
+				this.is_loading = false;
 				this.showError(error);
 			}
 		});


### PR DESCRIPTION
Las reglas de work_log_rules se filtraban por user.store_id, pero todo lo demas del Registro de Pago trabaja por area de produccion: la produccion que se suma, los usuarios que se listan y total_users salen del area.

El resultado era que de los 5 panaderos del area Pan Dulce solo cobraba uno, el unico que quedo asignado a la tienda Centro (la unica con regla), y con la formula de esa tienda. Cinco areas completas pagaban 0 porque su tienda nunca tuvo regla, y a la inversa habia gente cobrando con la formula de un area a la que no pertenece.

Cambios:
- work_log_rules gana production_area_id (modelo y empty).
- El Registro de Pago resuelve la regla por area. Si el area todavia no tiene regla propia cae al esquema viejo por tienda, y es excluyente a proposito: si se acumularan, un usuario con regla de area Y regla de su tienda cobraria las dos. Cuando todas tengan area, esa rama se borra.
- Variables de pago estrena selector de area. De paso resuelve que solo se podian editar las reglas de la tienda del usuario logueado, asi que darle regla a otra tienda obligaba a loguearse con un usuario de ahi.

Requiere la columna en la base:
ALTER TABLE work_log_rules ADD COLUMN production_area_id INT NULL AFTER store_id;