### PR TITLE
list-production-area): oculta las areas dadas de baja

### DIFF
--- a/src/app/pages/list-production-area/list-production-area.component.ts
+++ b/src/app/pages/list-production-area/list-production-area.component.ts
@@ -25,7 +25,8 @@ export class ListProductionAreaComponent extends BaseComponent implements OnInit
 		(
 			mergeMap((_paramMap)=>
 			{
-				return this.production_area_rest.search({limit:99999})
+				//production_area.php no filtra por status, regresa tambien las dadas de baja
+				return this.production_area_rest.search({eq:{status:'ACTIVE'},limit:99999})
 			}),
 		)
 		.subscribe((response)=>


### PR DESCRIPTION
La lista pedia production_area sin filtro, asi que seguian saliendo las que tienen status DELETED. Se agrega eq:{status:'ACTIVE'} al search, como ya lo hacen list-item-store, list-merma-totals y list-payroll.

El filtro por defecto existe en production_area.php pero esta comentado. No se descomenta ahi porque escondería las areas dadas de baja para todos los consumidores, y el historico de produccion sigue apuntando a ellas.