### PR TITLE
fix(item): restaura batch_option, que el merge borro por completo

### DIFF
--- a/src/app/modules/shared/Empties/Item.ts
+++ b/src/app/modules/shared/Empties/Item.ts
@@ -6,6 +6,7 @@ export function item(): Item {
 		id: 0,
 		applicable_tax: 'DEFAULT',
 		availability_type: 'ALWAYS',
+		batch_option: 'NONE',
 		background: 'transparent',
 		brand_id: null,
 		category_id: null,

--- a/src/app/modules/shared/RestModels/Item.ts
+++ b/src/app/modules/shared/RestModels/Item.ts
@@ -3,6 +3,7 @@ export interface Item {
   background: string;
   applicable_tax: 'DEFAULT' | 'EXEMPT' | 'PERCENT';
   availability_type: 'ON_STOCK' | 'BY_ORDER' | 'ALWAYS';
+  batch_option: 'NONE' | 'BATCH_ONLY' | 'EXPIRATION_ONLY' | 'BATCH_AND_EXPIRATION';
   brand_id: number | null;
   category_id: number | null;
   clave_sat: string | null;


### PR DESCRIPTION
La propiedad estaba declarada dos veces y dos ramas la limpiaron a la vez: una quito la primera declaracion y la otra quito la segunda, asi que al mergear git aplico las dos eliminaciones y no quedo ninguna.

El codigo la usa en add-batch-stock, item-info y save-consignment-delivered, por lo que master no compila. Se restaura una sola vez, en su lugar alfabetico.